### PR TITLE
change multi line indent and line lentgh

### DIFF
--- a/core-settings.yml
+++ b/core-settings.yml
@@ -22,7 +22,8 @@ Metrics/PerceivedComplexity:
   Max: 10
 
 Style/ConditionalAssignment:
-  EnforcedStyle: assign_inside_condition
+  Enabled: false # this rule is dumb b/c it also includes (.. ? .. : ..) who would want to assign inside the condition here???
+  # EnforcedStyle: assign_inside_condition
 Style/Documentation:
   Enabled: false
 Style/CollectionMethods:


### PR DESCRIPTION
changing something like:
```ruby
Image.where(id: [1234, 5678])
     .each do |image|
       puts image
     end
```
to
```ruby
Image.where(id: [1234, 5678])
  .each do |image|
    puts image
  end
```