### PR TITLE
Revert "Update core-settings.yml"

### DIFF
--- a/core-settings.yml
+++ b/core-settings.yml
@@ -52,5 +52,5 @@ Naming/VariableNumber:
 # while i agree with this, we should use `?` for methods that return a boolean 
 # if the method does other stuff and happens to return a boolean we should NOT use `?`
 # so disabling this b/c its a terrible check
-Naming/PredicateName:
+Naming/PredicateMethod:
   Enabled: false 


### PR DESCRIPTION
Reverts CiscoSecurityServices/rubocop#14

@C-Higgins I'm not sure why you changed this, but `Naming/PredicateMethod` is definitely a valid cop (an annoying one at that), and `Naming/PredicateName` doesn't even seem to exist.